### PR TITLE
Fix TypeError exception in cryoem.py

### DIFF
--- a/cryoem.py
+++ b/cryoem.py
@@ -248,7 +248,7 @@ def generate_phantom_density(N,window,sigma,num_blobs,seed=None):
     coords = gencoords(N,3).reshape((N**3,3))
     inside_window = n.sum(coords**2,axis=1).reshape((N,N,N)) < window**2
 
-    curr_c = n.array([0,0,0])
+    curr_c = n.array([0.0, 0.0 ,0.0])
     curr_n = 0
     while curr_n < num_blobs:
         csigma = sigma*n.exp(0.25*n.random.randn())


### PR DESCRIPTION
TypeError exception will be thrown here in numpy 1.10.4, python 2.7.11

`curr_c` should be initialized as a float array.
